### PR TITLE
Bug fix - datetime.timestamp is a long int

### DIFF
--- a/components/system_time/system_time.cpp
+++ b/components/system_time/system_time.cpp
@@ -35,7 +35,7 @@ void SystemTimeComponent::set_start_datetime(ESPTime datetime) {
   }
 
   this->start_datetime_ = datetime.timestamp;
-  ESP_LOGD(TAG, "set start datetime %s => %d", datetime.strftime("%Y-%m-%d %H:%M:%S").c_str(), datetime.timestamp);
+  ESP_LOGD(TAG, "set start datetime %s => %ld", datetime.strftime("%Y-%m-%d %H:%M:%S").c_str(), datetime.timestamp);
   this->update();
 }
 
@@ -52,7 +52,7 @@ void SystemTimeComponent::set_current_datetime(ESPTime datetime) {
   }
 
   this->start_datetime_ = datetime.timestamp - (millis() / 1000);
-  ESP_LOGD(TAG, "set current datetime %s => %d", datetime.strftime("%Y-%m-%d %H:%M:%S").c_str(), datetime.timestamp);
+  ESP_LOGD(TAG, "set current datetime %s => %ld", datetime.strftime("%Y-%m-%d %H:%M:%S").c_str(), datetime.timestamp);
   this->update();
 }
 


### PR DESCRIPTION
Component wasn't compiling, because datetime.timestamp is a time_t (64-bit int), whereas the ESP_LOGD format string was expecting it to be a 32-bit int.